### PR TITLE
VAT-1117/1118: update api key generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,12 @@ This is an **Object** with the following structure:
 
 ```json
 {
-  service_host: <<service_host>>,
-  auth_token: <<auth_token>>
+  "service_host": "service_host",
+  "auth_token": "auth_token"
 }
 ```
 
-Where `<<service_host>>` is a string, and the value of it is the host where the **Vatis Tech Transcription Service** is located. And `<<auth_token>>` is a string, that is the **Authentication token** for connecting to the **Vatis Tech Transcription Service**.
+Where `service_host` is a string, and the value of it is the host where the **Vatis Tech Transcription Service** is located. And `auth_token` is a string, that is the **Authentication token** for connecting to the **Vatis Tech Transcription Service**.
 
 #### NOTE
 

--- a/README.md
+++ b/README.md
@@ -239,14 +239,30 @@ At the moment, only `ro_RO` is available.
 
 This is a **String** of your API key.
 
-In order to use this plugin, you will need to use a valid API key.
-
 To get one, please follow these instructions:
 
 1. If you do not have one, please create an account on [https://vatis.tech/](https://vatis.tech/).
 2. Log in to your account on [https://vatis.tech/login](https://vatis.tech/login).
 3. Got to the API key page on your account, [https://vatis.tech/account/api-key](https://vatis.tech/account/api-key).
 4. Copy the API key from there and add it to the `@vatis-tech/asr-client-js` constructor.
+
+### `connectionConfig`
+
+This is an **Object** with the following structure:
+
+```json
+{
+  service_host: <<service_host>>,
+  auth_token: <<auth_token>>
+}
+```
+
+Where `<<service_host>>` is a string, and the value of it is the host where the **Vatis Tech Transcription Service** is located. And `<<auth_token>>` is a string, that is the **Authentication token** for connecting to the **Vatis Tech Transcription Service**.
+
+#### NOTE
+
+You will only use one of the `connectionConfig` or `apiKey` method to connect to the **Vatis Tech Transcription Service**.
+You will use the `apiKey` when connecting to the **Vatis Tech Cloud API**, and you will use the `connectionConfig` method when using the **Vatis Tech On Premise Installation**, and you will be provided with the necessary `connectionConfig` object.
 
 ### `onData`
 

--- a/src/components/ApiKeyGenerator.js
+++ b/src/components/ApiKeyGenerator.js
@@ -7,7 +7,8 @@ class ApiKeyGenerator {
   xmlHttp;
   logger;
   errorHandler;
-  constructor({ apiUrl, responseCallback, apiKey, logger, errorHandler }) {
+  connectionConfig;
+  constructor({ apiUrl, responseCallback, apiKey, logger, errorHandler, connectionConfig }) {
     this.errorHandler = errorHandler;
 
     this.logger = logger;
@@ -20,6 +21,7 @@ class ApiKeyGenerator {
     this.apiUrl = apiUrl;
     this.responseCallback = responseCallback;
     this.apiKey = apiKey;
+    this.connectionConfig = connectionConfig;
     this.xmlHttp = new XMLHttpRequest();
     this.xmlHttp.onload = this.onLoad.bind(this);
     this.xmlHttp.onerror = this.onError.bind(this);
@@ -30,9 +32,21 @@ class ApiKeyGenerator {
       description: `@vatis-tech/asr-client-js: Here it is where the XMLHttpRequest happens to get a valid key for the LIVE ASR  service.`,
     });
 
-    this.xmlHttp.open("GET", this.apiUrl);
-    this.xmlHttp.setRequestHeader("Authorization", "Bearer " + this.apiKey);
-    this.xmlHttp.send();
+    if (this.connectionConfig && this.connectionConfig.service_host !== undefined && this.connectionConfig.auth_token !== undefined){
+      this.logger({
+        currentState: `@vatis-tech/asr-client-js: Initialized the "ApiKeyGenerator" plugin.`,
+        description: `@vatis-tech/asr-client-js: A valid key was received from the Vatis Tech API, in order to use the LIVE ASR service.`,
+      });
+      
+      this.responseCallback({
+        serviceHost: this.connectionConfig.service_host,
+        authToken: this.connectionConfig.auth_token,
+      });
+    } else {
+      this.xmlHttp.open("GET", this.apiUrl);
+      this.xmlHttp.setRequestHeader("Authorization", "Bearer " + this.apiKey);
+      this.xmlHttp.send();
+    }
   }
   onError(e) {
     this.logger({

--- a/src/components/ApiKeyGenerator.js
+++ b/src/components/ApiKeyGenerator.js
@@ -32,15 +32,23 @@ class ApiKeyGenerator {
       description: `@vatis-tech/asr-client-js: Here it is where the XMLHttpRequest happens to get a valid key for the LIVE ASR  service.`,
     });
 
-    if (this.connectionConfig && this.connectionConfig.service_host !== undefined && this.connectionConfig.auth_token !== undefined){
+    if (
+        this.connectionConfig && 
+        this.connectionConfig.service_host !== undefined && 
+        this.connectionConfig.auth_token !== undefined && 
+        typeof this.connectionConfig.service_host === "string" && 
+        typeof this.connectionConfig.auth_token === "string"
+    ) {
       this.logger({
         currentState: `@vatis-tech/asr-client-js: Initialized the "ApiKeyGenerator" plugin.`,
         description: `@vatis-tech/asr-client-js: A valid key was received from the Vatis Tech API, in order to use the LIVE ASR service.`,
       });
+
+      const bearer = "Bearer ";
       
       this.responseCallback({
         serviceHost: this.connectionConfig.service_host,
-        authToken: this.connectionConfig.auth_token,
+        authToken: `${this.connectionConfig.auth_token.startsWith(bearer) ? "" : bearer}${this.connectionConfig.auth_token}`,
       });
     } else {
       this.xmlHttp.open("GET", this.apiUrl);

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ class VatisTechClient {
   onFinalData;
   EnableOnCommandFinalFrame;
   flushPacketWasSent;
+  connectionConfig;
   constructor({
     service,
     model,
@@ -58,7 +59,8 @@ class VatisTechClient {
     onConfig,
     onPartialData,
     onFinalData,
-    EnableOnCommandFinalFrame
+    EnableOnCommandFinalFrame,
+    connectionConfig
   }) {
     this.flushPacketWasSent = false;
 
@@ -165,6 +167,7 @@ class VatisTechClient {
       apiKey: apiKey,
       logger: this.logger.bind(this),
       errorHandler: this.errorHandler,
+      connectionConfig: connectionConfig
     });
 
     // instantiante InstanceReservation - this will return on the responseCallback the streamUrl, reservationToken, and podName for the SocketIOClientGenerator to connect based on the serviceHost and authToken


### PR DESCRIPTION
This adds a new prop, `connectionConfig` which can let the users decide the `service_host `and `auth_token`. This will be mainly used by the On-premise installation.