### PR TITLE
VAT-278: add ws re use service host

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,13 @@ This is an **Object** with the following structure:
 ```json
 {
   "service_host": "service_host",
+  "use_same_service_host_on_ws_connection": true | false,
   "auth_token": "auth_token"
 }
 ```
 
 Where `service_host` is a string, and the value of it is the host where the **Vatis Tech Transcription Service** is located. And `auth_token` is a string, that is the **Authentication token** for connecting to the **Vatis Tech Transcription Service**.
+The `use_same_service_host_on_ws_connection` specifies if the returned live service IP should be ignored when making the connection, and the `service_host` should be used instead. It defaults to `false`.
 
 #### NOTE
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -253,11 +253,13 @@ This is an **Object** with the following structure:
 ```json
 {
   "service_host": "service_host",
+  "use_same_service_host_on_ws_connection": true | false,
   "auth_token": "auth_token"
 }
 ```
 
 Where `service_host` is a string, and the value of it is the host where the **Vatis Tech Transcription Service** is located. And `auth_token` is a string, that is the **Authentication token** for connecting to the **Vatis Tech Transcription Service**.
+The `use_same_service_host_on_ws_connection` specifies if the returned live service IP should be ignored when making the connection, and the `service_host` should be used instead. It defaults to `false`.
 
 #### NOTE
 

--- a/dist/cjs/components/ApiKeyGenerator.js
+++ b/dist/cjs/components/ApiKeyGenerator.js
@@ -55,7 +55,8 @@ var ApiKeyGenerator = /*#__PURE__*/function () {
         var bearer = "Bearer ";
         this.responseCallback({
           serviceHost: this.connectionConfig.service_host,
-          authToken: "".concat(this.connectionConfig.auth_token.startsWith(bearer) ? "" : bearer).concat(this.connectionConfig.auth_token)
+          authToken: "".concat(this.connectionConfig.auth_token.startsWith(bearer) ? "" : bearer).concat(this.connectionConfig.auth_token),
+          useSameServiceHostOnWsConnection: this.connectionConfig.use_same_service_host_on_ws_connection === true ? true : false
         });
       } else {
         this.xmlHttp.open("GET", this.apiUrl);

--- a/dist/cjs/components/InstanceReservation.js
+++ b/dist/cjs/components/InstanceReservation.js
@@ -24,6 +24,7 @@ var InstanceReservation = /*#__PURE__*/function () {
     (0, _defineProperty2["default"])(this, "xmlHttp", void 0);
     (0, _defineProperty2["default"])(this, "logger", void 0);
     (0, _defineProperty2["default"])(this, "errorHandler", void 0);
+    (0, _defineProperty2["default"])(this, "useSameServiceHostOnWsConnection", void 0);
     this.errorHandler = errorHandler;
     this.logger = logger;
     this.logger({
@@ -39,9 +40,11 @@ var InstanceReservation = /*#__PURE__*/function () {
     key: "init",
     value: function init(_ref2) {
       var serviceHost = _ref2.serviceHost,
-        authToken = _ref2.authToken;
+        authToken = _ref2.authToken,
+        useSameServiceHostOnWsConnection = _ref2.useSameServiceHostOnWsConnection;
       this.serviceHost = serviceHost;
       this.authToken = authToken;
+      this.useSameServiceHostOnWsConnection = useSameServiceHostOnWsConnection;
       this.logger({
         currentState: "@vatis-tech/asr-client-js: Initializing the \"InstanceReservation\" plugin.",
         description: "@vatis-tech/asr-client-js: Here it is where the XMLHttpRequest happens to reserve a live asr instance."
@@ -83,7 +86,7 @@ var InstanceReservation = /*#__PURE__*/function () {
       this.reservationToken = response.token;
       this.streamHost = response.stream_host.startsWith("http") ? response.stream_host : "".concat(streamHostType).concat(response.stream_host);
       this.responseCallback({
-        streamHost: this.streamHost,
+        streamHost: this.useSameServiceHostOnWsConnection ? this.serviceHost : this.streamHost,
         streamUrl: this.streamUrl,
         reservationToken: this.reservationToken,
         authToken: this.authToken

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -305,10 +305,12 @@ var VatisTechClient = /*#__PURE__*/function () {
     key: "initInstanceReservation",
     value: function initInstanceReservation(_ref3) {
       var serviceHost = _ref3.serviceHost,
-        authToken = _ref3.authToken;
+        authToken = _ref3.authToken,
+        useSameServiceHostOnWsConnection = _ref3.useSameServiceHostOnWsConnection;
       this.instanceReservation.init({
         serviceHost: serviceHost,
-        authToken: authToken
+        authToken: authToken,
+        useSameServiceHostOnWsConnection: useSameServiceHostOnWsConnection
       });
     }
 

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vatis-tech/asr-client-js",
-  "version": "2.0.8",
+  "version": "2.0.9-next.0",
   "description": "JavaScript client for Vatis Tech ASR services.",
   "main": "cjs/index.js",
   "scripts": {

--- a/dist/umd/vatis-tech-asr-client.umd.js
+++ b/dist/umd/vatis-tech-asr-client.umd.js
@@ -56,7 +56,8 @@ var ApiKeyGenerator = /*#__PURE__*/function () {
         var bearer = "Bearer ";
         this.responseCallback({
           serviceHost: this.connectionConfig.service_host,
-          authToken: "".concat(this.connectionConfig.auth_token.startsWith(bearer) ? "" : bearer).concat(this.connectionConfig.auth_token)
+          authToken: "".concat(this.connectionConfig.auth_token.startsWith(bearer) ? "" : bearer).concat(this.connectionConfig.auth_token),
+          useSameServiceHostOnWsConnection: this.connectionConfig.use_same_service_host_on_ws_connection === true ? true : false
         });
       } else {
         this.xmlHttp.open("GET", this.apiUrl);
@@ -124,6 +125,7 @@ var InstanceReservation = /*#__PURE__*/function () {
     (0, _defineProperty2["default"])(this, "xmlHttp", void 0);
     (0, _defineProperty2["default"])(this, "logger", void 0);
     (0, _defineProperty2["default"])(this, "errorHandler", void 0);
+    (0, _defineProperty2["default"])(this, "useSameServiceHostOnWsConnection", void 0);
     this.errorHandler = errorHandler;
     this.logger = logger;
     this.logger({
@@ -139,9 +141,11 @@ var InstanceReservation = /*#__PURE__*/function () {
     key: "init",
     value: function init(_ref2) {
       var serviceHost = _ref2.serviceHost,
-        authToken = _ref2.authToken;
+        authToken = _ref2.authToken,
+        useSameServiceHostOnWsConnection = _ref2.useSameServiceHostOnWsConnection;
       this.serviceHost = serviceHost;
       this.authToken = authToken;
+      this.useSameServiceHostOnWsConnection = useSameServiceHostOnWsConnection;
       this.logger({
         currentState: "@vatis-tech/asr-client-js: Initializing the \"InstanceReservation\" plugin.",
         description: "@vatis-tech/asr-client-js: Here it is where the XMLHttpRequest happens to reserve a live asr instance."
@@ -183,7 +187,7 @@ var InstanceReservation = /*#__PURE__*/function () {
       this.reservationToken = response.token;
       this.streamHost = response.stream_host.startsWith("http") ? response.stream_host : "".concat(streamHostType).concat(response.stream_host);
       this.responseCallback({
-        streamHost: this.streamHost,
+        streamHost: this.useSameServiceHostOnWsConnection ? this.serviceHost : this.streamHost,
         streamUrl: this.streamUrl,
         reservationToken: this.reservationToken,
         authToken: this.authToken
@@ -1159,10 +1163,12 @@ var VatisTechClient = /*#__PURE__*/function () {
     key: "initInstanceReservation",
     value: function initInstanceReservation(_ref3) {
       var serviceHost = _ref3.serviceHost,
-        authToken = _ref3.authToken;
+        authToken = _ref3.authToken,
+        useSameServiceHostOnWsConnection = _ref3.useSameServiceHostOnWsConnection;
       this.instanceReservation.init({
         serviceHost: serviceHost,
-        authToken: authToken
+        authToken: authToken,
+        useSameServiceHostOnWsConnection: useSameServiceHostOnWsConnection
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vatis-tech/asr-client-js",
-  "version": "2.0.8",
+  "version": "2.0.9-next.0",
   "description": "JavaScript client for Vatis Tech ASR services.",
   "main": "cjs/index.js",
   "scripts": {

--- a/src/components/ApiKeyGenerator.js
+++ b/src/components/ApiKeyGenerator.js
@@ -33,11 +33,11 @@ class ApiKeyGenerator {
     });
 
     if (
-        this.connectionConfig && 
-        this.connectionConfig.service_host !== undefined && 
-        this.connectionConfig.auth_token !== undefined && 
-        typeof this.connectionConfig.service_host === "string" && 
-        typeof this.connectionConfig.auth_token === "string"
+      this.connectionConfig &&
+      this.connectionConfig.service_host !== undefined &&
+      this.connectionConfig.auth_token !== undefined &&
+      typeof this.connectionConfig.service_host === "string" &&
+      typeof this.connectionConfig.auth_token === "string"
     ) {
       this.logger({
         currentState: `@vatis-tech/asr-client-js: Initialized the "ApiKeyGenerator" plugin.`,
@@ -45,10 +45,11 @@ class ApiKeyGenerator {
       });
 
       const bearer = "Bearer ";
-      
+
       this.responseCallback({
         serviceHost: this.connectionConfig.service_host,
         authToken: `${this.connectionConfig.auth_token.startsWith(bearer) ? "" : bearer}${this.connectionConfig.auth_token}`,
+        useSameServiceHostOnWsConnection: this.connectionConfig.use_same_service_host_on_ws_connection === true ? true : false
       });
     } else {
       this.xmlHttp.open("GET", this.apiUrl);

--- a/src/components/InstanceReservation.js
+++ b/src/components/InstanceReservation.js
@@ -11,6 +11,7 @@ class InstanceReservation {
   xmlHttp;
   logger;
   errorHandler;
+  useSameServiceHostOnWsConnection;
   constructor({ responseCallback, logger, errorHandler }) {
     this.errorHandler = errorHandler;
 
@@ -25,9 +26,10 @@ class InstanceReservation {
     this.xmlHttp.onload = this.onLoad.bind(this);
     this.xmlHttp.onerror = this.onError.bind(this);
   }
-  init({ serviceHost, authToken }) {
+  init({ serviceHost, authToken, useSameServiceHostOnWsConnection }) {
     this.serviceHost = serviceHost;
     this.authToken = authToken;
+    this.useSameServiceHostOnWsConnection = useSameServiceHostOnWsConnection;
 
     this.logger({
       currentState: `@vatis-tech/asr-client-js: Initializing the "InstanceReservation" plugin.`,
@@ -72,7 +74,7 @@ class InstanceReservation {
     this.reservationToken = response.token;
     this.streamHost = response.stream_host.startsWith("http") ? response.stream_host : `${streamHostType}${response.stream_host}`;
     this.responseCallback({
-      streamHost: this.streamHost,
+      streamHost: this.useSameServiceHostOnWsConnection ? this.serviceHost : this.streamHost,
       streamUrl: this.streamUrl,
       reservationToken: this.reservationToken,
       authToken: this.authToken,

--- a/src/index.js
+++ b/src/index.js
@@ -287,8 +287,8 @@ class VatisTechClient {
 
   // initilize InstanceReservation
   // get a reserved link for socket.io-client
-  initInstanceReservation({ serviceHost, authToken }) {
-    this.instanceReservation.init({ serviceHost, authToken });
+  initInstanceReservation({ serviceHost, authToken, useSameServiceHostOnWsConnection }) {
+    this.instanceReservation.init({ serviceHost, authToken, useSameServiceHostOnWsConnection });
   }
 
   // initilize SocketIOClientGenerator


### PR DESCRIPTION
Add new prop on the `connectionConfig` to specify that you want to use on the WebSocket connection, the same `service_host` as the one from `connectionConfig`